### PR TITLE
Change default MG from 8MB to 2MB

### DIFF
--- a/BUIP-HF/buip-hf-technical-spec.md
+++ b/BUIP-HF/buip-hf-technical-spec.md
@@ -121,7 +121,7 @@ produce immediately after the fork.
 NOTE 1: The DEFAULT_MAX_GENERATED_BLOCK_SIZE in the released client needs
 to remain 1,000,000 bytes so that the client will not generate invalid
 blocks before the fork activates. At activation time, however, the "fork MG"
-specified by the user (default: 8MB) will take effect.
+specified by the user (default: 2MB) will take effect.
 
 
 ### REQ-5 (max tx / max block sigops rules for blocks > 1 MB)


### PR DESCRIPTION
As per discussion, this makes thing generally safer. We want to have a smooth rollout from 1MB to bigger block, not an order of magnitude of increase at once.