### PR TITLE
Add BUIP70 and BUIP76

### DIFF
--- a/070.mediawiki
+++ b/070.mediawiki
@@ -42,6 +42,8 @@ BUCash should develop the following:
 ==References==
 
 [https://support.bitpay.com/hc/en-us/articles/115004671663 BitPay's blog about the new address format]
+
 [https://bitpay.github.io/address-translator/ BitPay's address translator]
+
 [https://bitcoinclassic.com/news/release137uahf.html Basic support in Bitcoin Classic 1.3.7]
 

--- a/070.mediawiki
+++ b/070.mediawiki
@@ -1,0 +1,47 @@
+<pre>
+BUIP070: Support BitPay's new Bitcoin Cash address format in BUCash
+Proposer: Gal Buki
+Submitted on: 2017-11-08
+Status: draft
+</pre>
+
+==Motivation==
+
+Bitcoin and Bitcoin Cash share the same address format.
+This had the effect that users have sent BTC or BCH to an address that was used on the other chain such that if the other party does not recognize that chain the coins are "lost".
+
+In addition users have sent BCH to SegWit addresses making them unspendable on the BCH chain even if the owner had the private key.
+
+==Objectives==
+
+Implement a new address format that only needs minimal changes on the wallet side but would make the addresses distinguishable from each other such that users do not send funds to addresses from wallets that use the BTC chain.
+
+==Solution==
+
+Use the new address format which has been implemented by BitPay in their Copay wallet by changing the version byte of the address.
+The version byte is set to 28 for p2pkh addresses and 40 for p2sh addresses.
+
+Example p2pkh
+Old format: 1422ciKobfkK2Zk3TpNSebmEBEtDHEP5nG
+New format: CKUvBkfsUiiqvheU9ZhNE7PFoN6d99oMoo
+
+Example p2sh
+Old format: 36XTMVtgJqqNYymsSvRonpUsbZRGkm1jvX
+New format: HBMZpJKmAA43B9euJc5xmD1QdDSHh9j6kR
+
+==Development task==
+
+BUCash should develop the following:
+
+* allow to use the new address format when sending a payment
+* allow to use the new address format when signing and verifying a message
+* allow to configure in the GUI if addresses should be displayed in the new or old format
+* provide a command line argument to convert the old format to the new and vice versa
+
+
+==References==
+
+[https://support.bitpay.com/hc/en-us/articles/115004671663 BitPay's blog about the new address format]
+[https://bitpay.github.io/address-translator/ BitPay's address translator]
+[https://bitcoinclassic.com/news/release137uahf.html Basic support in Bitcoin Classic 1.3.7]
+

--- a/070.mediawiki
+++ b/070.mediawiki
@@ -1,6 +1,6 @@
 <pre>
 BUIP070: Support BitPay's new Bitcoin Cash address format in BUCash
-Proposer: Gal Buki
+Proposer: Gal Buki (@torusJKL)
 Submitted on: 2017-11-08
 Status: draft
 </pre>

--- a/070.mediawiki
+++ b/070.mediawiki
@@ -21,13 +21,15 @@ Implement a new address format that only needs minimal changes on the wallet sid
 Use the new address format which has been implemented by BitPay in their Copay wallet by changing the version byte of the address.
 The version byte is set to 28 for p2pkh addresses and 40 for p2sh addresses.
 
-Example p2pkh
-Old format: 1422ciKobfkK2Zk3TpNSebmEBEtDHEP5nG
-New format: CKUvBkfsUiiqvheU9ZhNE7PFoN6d99oMoo
 
-Example p2sh
-Old format: 36XTMVtgJqqNYymsSvRonpUsbZRGkm1jvX
-New format: HBMZpJKmAA43B9euJc5xmD1QdDSHh9j6kR
+;Example p2pkh
+: Old format: 1422ciKobfkK2Zk3TpNSebmEBEtDHEP5nG
+: New format: CKUvBkfsUiiqvheU9ZhNE7PFoN6d99oMoo
+
+
+;Example p2sh
+: Old format: 36XTMVtgJqqNYymsSvRonpUsbZRGkm1jvX
+: New format: HBMZpJKmAA43B9euJc5xmD1QdDSHh9j6kR
 
 ==Development task==
 

--- a/076.mediawiki
+++ b/076.mediawiki
@@ -1,6 +1,6 @@
 <pre>
 BUIP076: Support Base32 address format in BUCash
-Proposer: Gal Buki
+Proposer: Gal Buki (@torusJKL)
 Submitted on: 2017-11-17
 Status: draft
 </pre>

--- a/076.mediawiki
+++ b/076.mediawiki
@@ -1,0 +1,42 @@
+<pre>
+BUIP076: Support Base32 address format in BUCash
+Proposer: Gal Buki
+Submitted on: 2017-11-17
+Status: draft
+</pre>
+
+==Motivation==
+
+Bitcoin and Bitcoin Cash share the same address format.
+This had the effect that users have sent BTC or BCH to an address that was used on the other chain such that if the other party does not recognize that chain the coins are "lost".
+
+In addition users have sent BCH to SegWit addresses making them unspendable on the BCH chain even if the owner had the private key.
+
+==Objectives==
+
+Implement a new address format that would make the addresses distinguishable from each other such that users do not send funds to addresses from wallets that use the BTC chain.
+
+==Solution==
+
+Use the Base32 cashaddr format as proposed on the bitcoin-ml mailing list.
+
+==Development task==
+
+BUCash should develop the following:
+
+* allow to use the new address format when sending a payment
+* allow to use the new address format when signing and verifying a message
+* allow to configure in the GUI if addresses should be displayed in the new or old format
+* provide a command line argument to convert the old format to the new and vice versa
+
+
+At the time of writing the BUIP the specification has not yet been finalized.
+The Bitcoin Unlimited lead developer is encouraged to participate in the discussion and represent BU in this matter.
+
+Should there be no consensus on the specification than it is up to the Bitcoin Unlimited lead developer's discretion to choose between the proposed cashaddr solutions.
+
+==References==
+
+[https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md Specs: Address format for Bitcoin Cash]
+[https://lists.linuxfoundation.org/pipermail/bitcoin-ml/2017-November/000472.html bitcoin-ml discussion]
+

--- a/076.mediawiki
+++ b/076.mediawiki
@@ -38,5 +38,6 @@ Should there be no consensus on the specification than it is up to the Bitcoin U
 ==References==
 
 [https://github.com/Bitcoin-UAHF/spec/blob/master/cashaddr.md Specs: Address format for Bitcoin Cash]
+
 [https://lists.linuxfoundation.org/pipermail/bitcoin-ml/2017-November/000472.html bitcoin-ml discussion]
 

--- a/README.mediawiki
+++ b/README.mediawiki
@@ -410,4 +410,16 @@ This is the current list of submitted BUIPs.
 |Andrew Clifford (@solex)
 |2017-09-09
 | ---
+|-
+|[[070.mediawiki|BUIP070]]
+|Support BitPay's new Bitcoin Cash address format in BUCash
+|Gal Buki (@torusJKL)
+|2017-11-08
+| ---
+|-
+|[[076.mediawiki|BUIP076]]
+|Support Base32 address format in BUCash
+|Gal Buki (@torusJKL)
+|2017-11-17
+| ---
 |}


### PR DESCRIPTION
[BUIP70: Support BitPay's new Bitcoin Cash address format in BUCash](https://bitco.in/forum/threads/buip070-support-bitpays-new-bitcoin-cash-address-format-in-bucash.5285/)

[BUIP76: Support Base32 address format in BUCash](https://bitco.in/forum/threads/buip076-support-base32-address-format-in-bucash.7489/)