### PR TITLE
correct status for BUIP060 and BUIP081

### DIFF
--- a/README.mediawiki
+++ b/README.mediawiki
@@ -373,7 +373,7 @@ This is the current list of submitted BUIPs.
 |New Members for Election #6
 |Andrew Clifford (@solex)
 |2017-05-22
-| ---
+|passed
 |-
 |[[061.mediawiki|BUIP061]]
 |Demonstration of Phase in Full Network Upgrade Activated by Miners
@@ -493,7 +493,7 @@ This is the current list of submitted BUIPs.
 |Unambiguous definition of 1 year membership period
 |Gal Buki (@torusJKL)
 |2017-11-26
-|passed
+|closed
 |-
 |[[082.mediawiki|BUIP082]]
 |opt-in malleability fix


### PR DESCRIPTION
updated according to the forum.

BUIP060: https://bitco.in/forum/threads/voting-is-closed-for-buips-26-49-50-51-52-53-54-55-56-57-60.2167/page-2#post-39780

BUIP081: https://bitco.in/forum/threads/voting-is-closed-for-buips-68-70-71-72-73-74-75-76-77-78-80-81.7743/page-2#post-53628